### PR TITLE
Define the rail lib as riot module, so the linker can find it

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,5 @@
 MODULE = gecko_sdk
 
-DIRS += emlib/src emlib-extra/src
+DIRS += emlib/src emlib-extra/src radio
 
 include $(RIOTBASE)/Makefile.base

--- a/dist/radio/Makefile
+++ b/dist/radio/Makefile
@@ -1,0 +1,19 @@
+MODULE = gecko_sdk_librail
+
+RAIL_SDK_SRCDIR = $(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib
+
+ifeq ($(EFM32_FAMILY),efr32mg1p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg1_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32mg12p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg12_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32mg13p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg13_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32fg14p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg14_gcc_release.a
+endif
+
+$(BINDIR)/$(MODULE).a:
+	cp $(RAIL_LIB) $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 MODULE = gecko_sdk
 
-DIRS += emlib/src emlib-extra/src
+DIRS += emlib/src emlib-extra/src radio
 
 include $(RIOTBASE)/Makefile.base

--- a/src/radio/Makefile
+++ b/src/radio/Makefile
@@ -1,0 +1,19 @@
+MODULE = gecko_sdk_librail
+
+RAIL_SDK_SRCDIR = $(PKGDIRBASE)/gecko_sdk/dist/radio/rail_lib
+
+ifeq ($(EFM32_FAMILY),efr32mg1p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg1_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32mg12p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg12_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32mg13p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg13_gcc_release.a
+endif
+ifeq ($(EFM32_FAMILY),efr32fg14p)
+  RAIL_LIB = $(RAIL_SDK_SRCDIR)/autogen/librail_release/librail_efr32xg14_gcc_release.a
+endif
+
+$(BINDIR)/$(MODULE).a:
+	cp $(RAIL_LIB) $@


### PR DESCRIPTION
To be able to link the silabs rail lib, the riot build system needs target. As a module it can be configured as the other modules. 