### PR TITLE
bugfix: gecko boards without radio, do not need the radio driver blob

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,9 @@
 MODULE = gecko_sdk
 
-DIRS += emlib/src emlib-extra/src radio
+DIRS += emlib/src emlib-extra/src 
+
+ifneq (,$(filter rail,$(USEMODULE)))
+  DIRS += radio
+endif
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
It is not so nice, but it works ...